### PR TITLE
lower case to link to imagemagick section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@
     * compilation arguments
     * compiler optimizations
     * make and CMake
-see [Building External Libraries](#ImageMagick)
+see [Building External Libraries](#imagemagick)
 
     * bit shifting >> <<
     * binary operators &, |, ~


### PR DESCRIPTION
'Course, maybe linking to the "Building libraries" title just prior to the ImageMagick section would be more apropos? i.e.
[Building External Libraries](#building-libraries)